### PR TITLE
expose render function

### DIFF
--- a/ui/dev/ssr-dev.php
+++ b/ui/dev/ssr-dev.php
@@ -1,17 +1,16 @@
 <?php
 $page = $_GET['page'] ?? 'index';
 list($app, $preloadState, $ssrMetas) = require(__DIR__ . "/config/{$page}.php");
+$preloadStateJson = json_encode($preloadState, JSON_HEX_TAG);
+$ssrMetasJspm = json_encode($ssrMetas, JSON_HEX_TAG);
 ?>
-<script>
-  var __PRELOADED_STATE__ = <?php echo json_encode($preloadState, JSON_HEX_TAG);?>;
-  var __SSR_METAS__ = <?php echo json_encode($ssrMetas, JSON_HEX_TAG);?>;
-</script>
 <script src="build/<?=$app?>_ssr.bundle.js"></script>
 <script>
-  console.log("__PRELOADED_STATE__:", window.__PRELOADED_STATE__);
-  console.log("__SSR_METAS__:", window.__SSR_METAS__);
-  console.log("__SERVER_SIDE_MARKUP__:", window.__SERVER_SIDE_MARKUP__);
+  var markup = render(<?= $preloadStateJson ?>,<?= $ssrMetasJspm ?>);
+  console.log("__PRELOADED_STATE__:", <?= $preloadStateJson ?>);
+  console.log("METAS:", <?= $ssrMetasJspm ?>);
+  console.log("MARKUP:\n",markup);
 </script>
 <script>
-  document.write(window.__SERVER_SIDE_MARKUP__);
+  document.write(markup);
 </script>

--- a/ui/dev/ssr.php
+++ b/ui/dev/ssr.php
@@ -9,14 +9,12 @@ $page = $_GET['page'] ?? 'index';
 list($app, $preloadState, $ssrMetas) = require(__DIR__ . "/config/{$page}.php");
 $code = sprintf('var console = {warn: function(){}, error: function(){}};
 var global = global || this, self = self || this, window = window || this;
-window.__PRELOADED_STATE__ = %s;
-window.__SSR_METAS__ = %s;
 %s
-window.__SERVER_SIDE_MARKUP__;
+window.__SERVER_SIDE_MARKUP__ = render(%s,%s);
 ',
+    file_get_contents(__DIR__ . "/build/{$app}_ssr.bundle.js"),
     json_encode($preloadState),
-    json_encode($ssrMetas),
-    file_get_contents(__DIR__ . "/build/{$app}_ssr.bundle.js")
+    json_encode($ssrMetas)
 );
 $start = microtime(true);
 $html = $phpexecjs->evalJs($code);

--- a/ui/src/page/index/server/index.js
+++ b/ui/src/page/index/server/index.js
@@ -1,4 +1,3 @@
 import render from './render';
 
-/* eslint-disable */
-window.__SERVER_SIDE_MARKUP__ = render(window.__PRELOADED_STATE__, window.__SSR_METAS__);
+global.render = render;


### PR DESCRIPTION
Expose server side `render()` function not the result.

This is necessary oy use  V8 snap_shot functionality. Because V8 can take snapshot "render" function with entire app and library (Redux+React). Then only minimum user code is parsed and run on runtime.

```
const html = render(state, meta)
```